### PR TITLE
fix(migrations): complete Sub2API→claude2api pre-rename checksum compat (add 038)

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -77,6 +77,12 @@ var migrationChecksumCompatibilityRules = map[string]migrationChecksumCompatibil
 	"119_enforce_payment_orders_out_trade_no_unique.sql":      newMigrationChecksumCompatibilityRule("0bbe809ae48a9d811dabda1ba1c74955bd71c4a9cc610f9128816818dfa6c11e", "ebd2c67cce0116393fb4f1b5d5116a67c6aceb73820dfb5133d1ff6f36d72d34"),
 	"120_enforce_payment_orders_out_trade_no_unique_notx.sql": newMigrationChecksumCompatibilityRule("34aadc0db59a4e390f92a12b73bd74642d9724f33124f73638ae00089ea5e074", "e77921f79d539bc24575cb9c16cbe566d2b23ce816190343d0a7568f6a3fcf61", "707431450603e70a43ce9fbd61e0c12fa67da4875158ccefabacea069587ab22", "04b082b5a239c525154fe9185d324ee2b05ff90da9297e10dba19f9be79aa59a"),
 	"123_fix_legacy_auth_source_grant_on_signup_defaults.sql": newMigrationChecksumCompatibilityRule("2ce43c2cd89e9f9e1febd34a407ed9e84d177386c5544b6f02c1f58a21129f57", "6cd33422f215dcd1f486ab6f35c0ea5805d9ca69bb25906d94bc649156657145"),
+	// 仓库命名清理（Sub2API -> claude2api）仅改动迁移文件首行/注释文字，DDL 与 schema 完全不变；
+	// 旧库记录的是清理前 checksum，放行以兼容历史部署，避免要求人工修 checksum 或重建数据库。
+	"001_init.sql":                       newMigrationChecksumCompatibilityRule("dc7c7282d64c54248d21a39673c651f50529b712643f140e1c6150adccceb986", "9ba0369779484625edcea7a7d1d4582397e31546db9149b05004990a3f16c630"),
+	"002_account_type_migration.sql":     newMigrationChecksumCompatibilityRule("02fa8b90d345b288a0a1e3f2d5a8a3a569827d394f5ddae7bcadc1e7e95d89ea", "aad3816e44f58ff007ea4df8092aae580f3f85180314c1deb1b1054b20892bbf"),
+	"003_subscription.sql":               newMigrationChecksumCompatibilityRule("518aac1e666fb0358f9ac0252117795dfd08f98e4c68f2ae5c8513636a2d2a9f", "4642fcb1ccd7954b1d3eef8f795cfba2ce21431257346cc5a7568cde61a60b13"),
+	"052_migrate_upstream_to_apikey.sql": newMigrationChecksumCompatibilityRule("7662a2b3ace749ae153d9033fc4482fff40df198977a0fef38762afe85e0233f", "d2ea657ec24995664a8ddc1bfb9c3fe317646c7bcd12517dee8478bc6c36244a"),
 }
 
 // ApplyMigrations 将嵌入的 SQL 迁移文件应用到指定的数据库。

--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -83,6 +83,9 @@ var migrationChecksumCompatibilityRules = map[string]migrationChecksumCompatibil
 	"002_account_type_migration.sql":     newMigrationChecksumCompatibilityRule("02fa8b90d345b288a0a1e3f2d5a8a3a569827d394f5ddae7bcadc1e7e95d89ea", "aad3816e44f58ff007ea4df8092aae580f3f85180314c1deb1b1054b20892bbf"),
 	"003_subscription.sql":               newMigrationChecksumCompatibilityRule("518aac1e666fb0358f9ac0252117795dfd08f98e4c68f2ae5c8513636a2d2a9f", "4642fcb1ccd7954b1d3eef8f795cfba2ce21431257346cc5a7568cde61a60b13"),
 	"052_migrate_upstream_to_apikey.sql": newMigrationChecksumCompatibilityRule("7662a2b3ace749ae153d9033fc4482fff40df198977a0fef38762afe85e0233f", "d2ea657ec24995664a8ddc1bfb9c3fe317646c7bcd12517dee8478bc6c36244a"),
+	// 038 与上述四个文件同属 9afaa312 命名清理：其首行注释及一处 owner 归一化 WHERE 条件由 sub2api 改为 claude2api，
+	// 改变了 trimmed-content checksum，但该迁移在历史库早已应用、不会重跑，故 schema/数据不受影响，仅需放行 checksum。
+	"038_ops_errors_resolution_retry_results_and_standardize_classification.sql": newMigrationChecksumCompatibilityRule("3281353a2e475fa22932b101160fc25bdaaaf4a6051ca5f4f974c21ec39b85a2", "4cc121d97c7f59e9def9397b7d0314d4dfbfe4cd831698359456dd49bf995ece"),
 }
 
 // ApplyMigrations 将嵌入的 SQL 迁移文件应用到指定的数据库。


### PR DESCRIPTION
## 背景

`9afaa312` (clean public repository presentation) 改写了 **5 个** migration 文件,把首行注释 `Sub2API` 改为 `claude2api`(038 还额外把一处 owner 归一化 `WHERE` 条件 `sub2api`→`claude2api`)。这些改动 **DDL/schema 完全不变**,但改变了 trimmed-content checksum。已有部署(尤其从旧 sub2api 迁移而来的库)在 `schema_migrations` 里记录的是清理前 checksum,从源码 rebuild 的镜像会因 checksum mismatch **启动失败**。

`32a46e33` 为其中 **4 个**文件(001/002/003/052)加了兼容规则,但 **遗漏了 038**。任何人从主干 rebuild 并部署到此类迁移库都会撞上:

```
038_..._classification.sql checksum mismatch (db=4cc121d9... file=3281353a...)
```

## 改动

本 PR 包含两个 commit:
1. `32a46e33` 的内容(001/002/003/052 兼容规则)
2. 新增 038 兼容规则,补全 9afaa312 影响的全部 5 个文件

## 验证

用一台从 sub2api 迁移而来的生产库**快照**实测:打补丁前镜像因 038 checksum mismatch 启动失败;打补丁后容器正常 healthy,`/health`=200,全程 0 次 checksum mismatch、0 次 Auto setup failed。已据此完成一次生产部署。